### PR TITLE
Minor fix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ USAGE
 
 ```
 ./udpbroadcastrelay \
-    -id id \
+    --id id \
     --port <udp-port> \
     --dev eth0 --dev eth1
     [--dev ethx...] \


### PR DESCRIPTION
Tiny typo, but the `id` parameter needs a double hyphen, right? 