### PR TITLE
fix install for BSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ clean:
 all: udpbroadcastrelay
 
 install:
-	install -Dpm0755 -t $(DESTDIR)$(PREFIX)/sbin/ udpbroadcastrelay
+	install -pm0755 udpbroadcastrelay $(DESTDIR)$(PREFIX)/sbin/


### PR DESCRIPTION
The -D and -t flags are not supported on BSD with the same meaning as Linux.